### PR TITLE
Compatibilty with TYPO3 v12.4.11 onwards

### DIFF
--- a/Classes/Command/CheckApiCommand.php
+++ b/Classes/Command/CheckApiCommand.php
@@ -24,7 +24,7 @@ class CheckApiCommand extends Command
     /**
      * Execute the checkApi command
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $apiService = GeneralUtility::makeInstance(ApiService::class);
         $io = new SymfonyStyle($input, $output);

--- a/Classes/Command/UpdateCommand.php
+++ b/Classes/Command/UpdateCommand.php
@@ -24,7 +24,7 @@ class UpdateCommand extends Command
     /**
      * Execute the update command
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $apiService = GeneralUtility::makeInstance(ApiService::class);
         $io = new SymfonyStyle($input, $output);


### PR DESCRIPTION
After updating to v12.4.11, it seems there is a simfony update resulting in this error message:

PHP Fatal error:  Declaration of Derhansen\Tobserver\Command\UpdateCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int

The pull request adds return types to the commands